### PR TITLE
Allow notes max length to be configured

### DIFF
--- a/ui-src/src/components/DispositionTab.tsx
+++ b/ui-src/src/components/DispositionTab.tsx
@@ -9,7 +9,7 @@ import { HelpText } from '@twilio-paste/core/help-text';
 import { Box } from '@twilio-paste/core/box';
 import { debounce } from 'lodash';
 
-import { getDispositionsForQueue, isNotesEnabled, isRequireDispositionEnabledForQueue } from '../utils/config';
+import { getDispositionsForQueue, isNotesEnabled, isRequireDispositionEnabledForQueue, getNotesMaxLength } from '../utils/config';
 import { AppState } from '../flex-hooks/states';
 import { reduxNamespace } from '../flex-hooks/states';
 import { updateDisposition, DispositionsState } from '../flex-hooks/states';
@@ -20,7 +20,7 @@ export interface OwnProps {
 }
 
 const DispositionTab = (props: OwnProps) => {
-  const NOTES_MAX_LENGTH = 100;
+  const NOTES_MAX_LENGTH = getNotesMaxLength() ?? 100;
   const [disposition, setDisposition] = useState('');
   const [notes, setNotes] = useState('');
 

--- a/ui-src/src/utils/config.ts
+++ b/ui-src/src/utils/config.ts
@@ -12,6 +12,7 @@ interface UIAttributes extends FlexUIAttributes {
 const { custom_data } = Flex.Manager.getInstance().configuration as UIAttributes;
 const {
   enable_notes = false,
+  notes_max_length = 100,
   require_disposition = false,
   global_dispositions = [],
   per_queue = {},
@@ -20,6 +21,10 @@ const {
 export const isNotesEnabled = () => {
   return enable_notes;
 };
+
+export const getNotesMaxLengh = () => {
+  return notes_max_length;
+}
 
 export const isRequireDispositionEnabledForQueue = (queueSid: string) => {
   let required = require_disposition;

--- a/ui-src/src/utils/config.ts
+++ b/ui-src/src/utils/config.ts
@@ -22,7 +22,7 @@ export const isNotesEnabled = () => {
   return enable_notes;
 };
 
-export const getNotesMaxLengh = () => {
+export const getNotesMaxLength = () => {
   return notes_max_length;
 }
 


### PR DESCRIPTION
Due to the need to expand notes max length. This PR adds configuration option for the length to allow customization.