### PR TITLE
FLEXY-5036 taskcanvas duplicate input fix

### DIFF
--- a/ui-src/src/components/DispositionTab.tsx
+++ b/ui-src/src/components/DispositionTab.tsx
@@ -19,33 +19,39 @@ export interface OwnProps {
   task?: ITask;
 }
 
-const DispositionTab = (props: OwnProps) => {
+const DispositionTab = ({task}: OwnProps) => {
   const NOTES_MAX_LENGTH = 100;
-  const [disposition, setDisposition] = useState('');
+  const taskSid = task && task?.taskSid || '';
   const [notes, setNotes] = useState('');
 
   const dispatch = useDispatch();
   const { tasks } = useSelector((state: AppState) => state[reduxNamespace] as DispositionsState);
+  const dispositionForTask = tasks && tasks[taskSid] ? tasks[taskSid].disposition : '';
+  const notesForTask = tasks && tasks[taskSid] ? tasks[taskSid].notes : '';
   const strings = Manager.getInstance().strings as any;
 
-  const updateStore = () => {
-    if (!props.task) return;
+  useEffect(()=>{
+    setNotes(notesForTask)
+  },[task?.taskSid])
+
+  const updateStore = (value="") => {
+    if (!task) return;
 
     let payload = {
-      taskSid: props.task.taskSid,
+      taskSid: task.taskSid,
       disposition: '',
       notes: '',
     };
 
-    if (tasks && tasks[props.task.taskSid]) {
+    if (tasks && tasks[task.taskSid]) {
       payload = {
         ...payload,
-        ...tasks[props.task.taskSid],
+        ...tasks[task.taskSid],
       };
     }
 
-    if (disposition) {
-      payload.disposition = disposition;
+    if (value) {
+      payload.disposition = value;
     }
 
     if (isNotesEnabled() && notes) {
@@ -57,21 +63,12 @@ const DispositionTab = (props: OwnProps) => {
   const updateStoreDebounced = debounce(updateStore, 250, { maxWait: 1000 });
 
   useEffect(() => {
-    if (tasks && props.task && tasks[props.task.taskSid]) {
-      if (tasks[props.task.taskSid].disposition) {
-        setDisposition(tasks[props.task.taskSid].disposition);
-      }
-
-      if (isNotesEnabled() && tasks[props.task.taskSid].notes) {
-        setNotes(tasks[props.task.taskSid].notes);
+    if (tasks && task && tasks[task.taskSid]) {
+      if (isNotesEnabled() && tasks[task.taskSid].notes) {
+        setNotes(tasks[task.taskSid].notes);
       }
     }
   }, []);
-
-  useEffect(() => {
-    if (!disposition) return;
-    updateStore();
-  }, [disposition]);
 
   useEffect(() => {
     if (!isNotesEnabled()) return;
@@ -82,32 +79,32 @@ const DispositionTab = (props: OwnProps) => {
     // Pop the disposition tab when the task enters wrapping status.
     // We do this here because WrapupTask does not handle a customer-ended task,
     // and doing this in the taskWrapup event seems to not work.
-    if (props.task?.status === 'wrapping') {
+    if (task?.status === 'wrapping') {
       Actions.invokeAction('SetComponentState', {
         name: 'AgentTaskCanvasTabs',
         state: { selectedTabName: 'disposition' },
       });
     }
-  }, [props.task?.status]);
+  }, [task?.status]);
 
   return (
     <Box padding="space80">
       <Stack orientation="vertical" spacing="space80">
-        {getDispositionsForQueue(props.task?.queueSid ?? '').length > 0 && (
+        {getDispositionsForQueue(task?.queueSid ?? '').length > 0 && (
           <RadioGroup
-            name={`${props.task?.sid}-disposition`}
-            value={disposition}
+            name={`${task?.sid}-disposition`}
+            value={dispositionForTask}
             legend={strings[StringTemplates.SelectDispositionTitle]}
             helpText={strings[StringTemplates.SelectDispositionHelpText]}
-            onChange={(value) => setDisposition(value)}
-            required={isRequireDispositionEnabledForQueue(props.task?.queueSid ?? '')}
+            onChange={(value) => updateStore(value)}
+            required={isRequireDispositionEnabledForQueue(task?.queueSid ?? '')}
           >
-            {getDispositionsForQueue(props.task?.queueSid ?? '').map((disp) => (
+            {getDispositionsForQueue(task?.queueSid ?? '').map((disp,i) => (
               <Radio
-                id={`${props.task?.sid}-disposition-${disp}`}
+                id={`${task?.sid}-disposition-${disp}${i}`}
                 value={disp}
-                name={`${props.task?.sid}-disposition`}
-                key={`${props.task?.sid}-disposition-${disp}`}
+                name={`${task?.sid}-disposition`}
+                key={`${task?.sid}-disposition-${disp}${i}`}
               >
                 {disp}
               </Radio>
@@ -120,8 +117,8 @@ const DispositionTab = (props: OwnProps) => {
             <TextArea
               onChange={(e) => setNotes(e.target.value)}
               aria-describedby="notes_help_text"
-              id={`${props.task?.sid}-notes`}
-              name={`${props.task?.sid}-notes`}
+              id={`${task?.sid}-notes`}
+              name={`${task?.sid}-notes`}
               value={notes}
               maxLength={NOTES_MAX_LENGTH}
             />


### PR DESCRIPTION
## Description

JIRA: [FLEXY-5036](https://issues.corp.twilio.com/browse/FLEXY-5036)

- DESCRIPTION_OF_PR

## Test Plan

- DESCRIPTION_OF_TEST_PLAN

## Checklist

- [ ] Individual public Repo in Twilio Github.com
- [ ] Test the plugin against Flex UI 2.x for compatibility
- [ ] Create plugin specific CI/CD files
- [ ] Unit test for UI code and serverless code (80% coverage)
- [ ] setup.js should be mandatorily part of the serverless functions
- [ ] Telemetry - Make use of the manager.reportPluginInteraction() to send the event data to Kibana
- [ ] For logging, console.log/warn/error should be effectively used with enough contextual information (these will by default show up in debugger once enabled)
- [ ] Exception handling with degraded UX or information to UI along with serverless retry mechanism (for wherever applicable)
  - 5xx should be handled with retry mechanism (max of 3 attempts)
  - 4xx should be reported back to user saying "Please try after some time...."
- [ ] Details.md file to have content that needs to show up on PluginsLibrary frontend
- [ ] License file to be added in the repo
- [ ] Readme.md updated
- [ ] Plugin template should have a screeshot folder, which contains one image (1.gif) of 1280 x 720 resolution (16:9 aspect ratio).
- [ ] Snyk integration for security vulenrabilities (fix them if there are any)
- [ ] CodeCov integration for testing coverage
- [ ] E2E test suite for the entire plugin
- [ ] For E2E or any automated test, container components and user interactable child components must have ID attribute set.
